### PR TITLE
Fix UnityWebRequestSender set null data from download handler

### DIFF
--- a/Packages/UGF.WebRequests/Runtime/Unity/UnityWebRequestSender.cs
+++ b/Packages/UGF.WebRequests/Runtime/Unity/UnityWebRequestSender.cs
@@ -78,10 +78,11 @@ namespace UGF.WebRequests.Runtime.Unity
             Dictionary<string, string> headers = unityWebRequest.GetResponseHeaders() ?? new Dictionary<string, string>();
             var statusCode = (HttpStatusCode)unityWebRequest.responseCode;
             var response = new WebResponse(headers, request.Method, request.Url, statusCode);
+            byte[] data = unityWebRequest.downloadHandler?.data;
 
-            if (unityWebRequest.downloadHandler != null)
+            if (data != null)
             {
-                response.SetData(unityWebRequest.downloadHandler.data);
+                response.SetData(data);
             }
 
             return Task.FromResult<IWebResponse>(response);

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.2.3f1
-m_EditorVersionWithRevision: 2021.2.3f1 (32358a8527b4)
+m_EditorVersion: 2021.2.4f1
+m_EditorVersionWithRevision: 2021.2.4f1 (99ba6aa4c552)


### PR DESCRIPTION
- Fix  `UnityWebRequestSender` class to check data from download handler when setup data for response.